### PR TITLE
Fix Storybook JSX Functions

### DIFF
--- a/src/ComponentSource/index.js
+++ b/src/ComponentSource/index.js
@@ -16,9 +16,29 @@ const componentToJSX = component =>
     functionValue: functionToString
   });
 
+const formatJSX = component => {
+  const jsx = componentToJSX(component);
+
+  let arr = jsx.split("IMPORTED_MODULE");
+
+  if (arr.length > 1) {
+    for (let i = 0; i < arr.length; i++) {
+      if (arr[i].includes("WEBPACK") && !arr[i].includes("{")) {
+        arr[i] = "";
+      } else if (arr[i].lastIndexOf("{") > arr[i].lastIndexOf("}")) {
+        arr[i] = arr[i].substring(0, arr[i].lastIndexOf("{") + 1) + " (rendered jsx) ";
+      } else {
+        arr[i] = arr[i].substring(arr[i].indexOf("}") , arr[i].length);
+      }
+    }
+  }
+  
+  return arr.join("");
+}
+
 // Given react component, render a source example
 const ComponentSource = ({ component }) => (
-  <CodeBlock source={componentToJSX(component)} />
+  <CodeBlock source={formatJSX(component)} />
 );
 
 ComponentSource.propTypes = {


### PR DESCRIPTION
When you use a function that returns jsx in a story
<img width="321" alt="Screen Shot 2019-04-08 at 2 38 23 PM" src="https://user-images.githubusercontent.com/15703789/55748357-6d37ed80-5a0c-11e9-9841-76f8d5993aa4.png">

Webpack turns it into gibberish when it comes time to display it
<img width="1121" alt="Screen Shot 2019-04-08 at 2 37 48 PM" src="https://user-images.githubusercontent.com/15703789/55748375-7aed7300-5a0c-11e9-9309-dcb9b8e3bf7e.png">

I wrote a simple function that replaces the mumbo jumbo with "(rendered jsx)"; ignore the lack of formatting here, result of a different issue that I'm trying to fix.
<img width="497" alt="Screen Shot 2019-04-08 at 2 42 42 PM" src="https://user-images.githubusercontent.com/15703789/55748414-9bb5c880-5a0c-11e9-9e83-3607f991ccae.png">
